### PR TITLE
ENG-518 Multiple mint recipients and supply amounts

### DIFF
--- a/custom_flatten/FabricaToken1155.sol
+++ b/custom_flatten/FabricaToken1155.sol
@@ -1819,6 +1819,236 @@ interface IValidator {
 }
 
 
+// Dependency file: @openzeppelin/contracts/utils/math/SafeMath.sol
+
+// OpenZeppelin Contracts (last updated v4.6.0) (utils/math/SafeMath.sol)
+
+// pragma solidity ^0.8.0;
+
+// CAUTION
+// This version of SafeMath should only be used with Solidity 0.8 or later,
+// because it relies on the compiler's built in overflow checks.
+
+/**
+ * @dev Wrappers over Solidity's arithmetic operations.
+ *
+ * NOTE: `SafeMath` is generally not needed starting with Solidity 0.8, since the compiler
+ * now has built in overflow checking.
+ */
+library SafeMath {
+    /**
+     * @dev Returns the addition of two unsigned integers, with an overflow flag.
+     *
+     * _Available since v3.4._
+     */
+    function tryAdd(uint256 a, uint256 b) internal pure returns (bool, uint256) {
+        unchecked {
+            uint256 c = a + b;
+            if (c < a) return (false, 0);
+            return (true, c);
+        }
+    }
+
+    /**
+     * @dev Returns the subtraction of two unsigned integers, with an overflow flag.
+     *
+     * _Available since v3.4._
+     */
+    function trySub(uint256 a, uint256 b) internal pure returns (bool, uint256) {
+        unchecked {
+            if (b > a) return (false, 0);
+            return (true, a - b);
+        }
+    }
+
+    /**
+     * @dev Returns the multiplication of two unsigned integers, with an overflow flag.
+     *
+     * _Available since v3.4._
+     */
+    function tryMul(uint256 a, uint256 b) internal pure returns (bool, uint256) {
+        unchecked {
+            // Gas optimization: this is cheaper than requiring 'a' not being zero, but the
+            // benefit is lost if 'b' is also tested.
+            // See: https://github.com/OpenZeppelin/openzeppelin-contracts/pull/522
+            if (a == 0) return (true, 0);
+            uint256 c = a * b;
+            if (c / a != b) return (false, 0);
+            return (true, c);
+        }
+    }
+
+    /**
+     * @dev Returns the division of two unsigned integers, with a division by zero flag.
+     *
+     * _Available since v3.4._
+     */
+    function tryDiv(uint256 a, uint256 b) internal pure returns (bool, uint256) {
+        unchecked {
+            if (b == 0) return (false, 0);
+            return (true, a / b);
+        }
+    }
+
+    /**
+     * @dev Returns the remainder of dividing two unsigned integers, with a division by zero flag.
+     *
+     * _Available since v3.4._
+     */
+    function tryMod(uint256 a, uint256 b) internal pure returns (bool, uint256) {
+        unchecked {
+            if (b == 0) return (false, 0);
+            return (true, a % b);
+        }
+    }
+
+    /**
+     * @dev Returns the addition of two unsigned integers, reverting on
+     * overflow.
+     *
+     * Counterpart to Solidity's `+` operator.
+     *
+     * Requirements:
+     *
+     * - Addition cannot overflow.
+     */
+    function add(uint256 a, uint256 b) internal pure returns (uint256) {
+        return a + b;
+    }
+
+    /**
+     * @dev Returns the subtraction of two unsigned integers, reverting on
+     * overflow (when the result is negative).
+     *
+     * Counterpart to Solidity's `-` operator.
+     *
+     * Requirements:
+     *
+     * - Subtraction cannot overflow.
+     */
+    function sub(uint256 a, uint256 b) internal pure returns (uint256) {
+        return a - b;
+    }
+
+    /**
+     * @dev Returns the multiplication of two unsigned integers, reverting on
+     * overflow.
+     *
+     * Counterpart to Solidity's `*` operator.
+     *
+     * Requirements:
+     *
+     * - Multiplication cannot overflow.
+     */
+    function mul(uint256 a, uint256 b) internal pure returns (uint256) {
+        return a * b;
+    }
+
+    /**
+     * @dev Returns the integer division of two unsigned integers, reverting on
+     * division by zero. The result is rounded towards zero.
+     *
+     * Counterpart to Solidity's `/` operator.
+     *
+     * Requirements:
+     *
+     * - The divisor cannot be zero.
+     */
+    function div(uint256 a, uint256 b) internal pure returns (uint256) {
+        return a / b;
+    }
+
+    /**
+     * @dev Returns the remainder of dividing two unsigned integers. (unsigned integer modulo),
+     * reverting when dividing by zero.
+     *
+     * Counterpart to Solidity's `%` operator. This function uses a `revert`
+     * opcode (which leaves remaining gas untouched) while Solidity uses an
+     * invalid opcode to revert (consuming all remaining gas).
+     *
+     * Requirements:
+     *
+     * - The divisor cannot be zero.
+     */
+    function mod(uint256 a, uint256 b) internal pure returns (uint256) {
+        return a % b;
+    }
+
+    /**
+     * @dev Returns the subtraction of two unsigned integers, reverting with custom message on
+     * overflow (when the result is negative).
+     *
+     * CAUTION: This function is deprecated because it requires allocating memory for the error
+     * message unnecessarily. For custom revert reasons use {trySub}.
+     *
+     * Counterpart to Solidity's `-` operator.
+     *
+     * Requirements:
+     *
+     * - Subtraction cannot overflow.
+     */
+    function sub(
+        uint256 a,
+        uint256 b,
+        string memory errorMessage
+    ) internal pure returns (uint256) {
+        unchecked {
+            require(b <= a, errorMessage);
+            return a - b;
+        }
+    }
+
+    /**
+     * @dev Returns the integer division of two unsigned integers, reverting with custom message on
+     * division by zero. The result is rounded towards zero.
+     *
+     * Counterpart to Solidity's `/` operator. Note: this function uses a
+     * `revert` opcode (which leaves remaining gas untouched) while Solidity
+     * uses an invalid opcode to revert (consuming all remaining gas).
+     *
+     * Requirements:
+     *
+     * - The divisor cannot be zero.
+     */
+    function div(
+        uint256 a,
+        uint256 b,
+        string memory errorMessage
+    ) internal pure returns (uint256) {
+        unchecked {
+            require(b > 0, errorMessage);
+            return a / b;
+        }
+    }
+
+    /**
+     * @dev Returns the remainder of dividing two unsigned integers. (unsigned integer modulo),
+     * reverting with custom message when dividing by zero.
+     *
+     * CAUTION: This function is deprecated because it requires allocating memory for the error
+     * message unnecessarily. For custom revert reasons use {tryMod}.
+     *
+     * Counterpart to Solidity's `%` operator. This function uses a `revert`
+     * opcode (which leaves remaining gas untouched) while Solidity uses an
+     * invalid opcode to revert (consuming all remaining gas).
+     *
+     * Requirements:
+     *
+     * - The divisor cannot be zero.
+     */
+    function mod(
+        uint256 a,
+        uint256 b,
+        string memory errorMessage
+    ) internal pure returns (uint256) {
+        unchecked {
+            require(b > 0, errorMessage);
+            return a % b;
+        }
+    }
+}
+
+
 // Root file: src/FabricaToken1155.sol
 
 // OpenZeppelin Contracts (last updated v4.8.0) (token/ERC1155/ERC1155.sol)
@@ -1832,6 +2062,9 @@ pragma solidity ^0.8.12;
 // import "@openzeppelin/contracts/utils/introspection/ERC165.sol";
 // import "@openzeppelin/contracts/utils/introspection/ERC165Checker.sol";
 // import "src/IFabricaValidator.sol";
+// import "@openzeppelin/contracts/utils/math/SafeMath.sol";
+
+using SafeMath for uint256;
 
 /**
  * @dev Implementation of the Fabrica ERC1155 multi-token.
@@ -1888,9 +2121,6 @@ contract FabricaToken is Context, ERC165, IERC1155, IERC1155MetadataURI, Ownable
      * @dev Delegate to the validator contract
      */
     function uri(uint256 id) override public view returns (string memory) {
-        if (_property[id].validator == address(0)) {
-            return "";
-        }
         return IValidator(_property[id].validator).uri(id);
     }
 
@@ -1898,21 +2128,27 @@ contract FabricaToken is Context, ERC165, IERC1155, IERC1155MetadataURI, Ownable
      * @dev `mint` allows users to mint to 3rd party (although it allows to mint to self as well)
      */
     function mint(
-        address to,
+        address[] memory recipients,
         uint256 sessionId,
-        uint256 supply,
+        uint256[] memory amounts,
         string memory definition,
         string memory operatingAgreement,
         string memory configuration,
         address validator
     ) public whenNotPaused returns (uint256) {
+        uint256 supply = 0;
+        for (uint256 i = 0; i < amounts.length; i++) {
+            uint256 amount = amounts[i];
+            require(amount > 0, 'Each amount must be greater than zero');
+            supply = supply.add(amount);
+        }
         Property memory property;
         property.supply = supply;
         property.operatingAgreement = operatingAgreement;
         property.definition = definition;
         property.configuration = configuration;
         property.validator = validator;
-        uint256 id = _mint(to, sessionId, property, "");
+        uint256 id = _mint(recipients, sessionId, amounts, property, "");
         return id;
     }
 
@@ -1920,24 +2156,30 @@ contract FabricaToken is Context, ERC165, IERC1155, IERC1155MetadataURI, Ownable
      * @dev `mintBatch` allows users to mint in bulk
      */
     function mintBatch(
-        address to,
+        address[] memory recipients,
         uint256[] memory sessionIds,
-        uint256[] memory supplies,
+        uint256[] memory amounts,
         string[] memory definitions,
         string[] memory operatingAgreements,
         string[] memory configurations,
         address[] memory validators
     ) public whenNotPaused returns (uint256[] memory ids) {
+        uint256 supply = 0;
+        for (uint256 i = 0; i < amounts.length; i++) {
+            uint256 amount = amounts[i];
+            require(amount > 0, 'Each amount must be greater than zero');
+            supply = supply.add(amount);
+        }
         uint256 size = sessionIds.length;
         Property[] memory properties = new Property[](size);
         for (uint256 i = 0; i < size; i++) {
-            properties[i].supply = supplies[i];
+            properties[i].supply = supply;
             properties[i].operatingAgreement = operatingAgreements[i];
             properties[i].definition = definitions[i];
             properties[i].configuration = configurations[i];
             properties[i].validator = validators[i];
         }
-        ids = _mintBatch(to, sessionIds, properties, "");
+        ids = _mintBatch(recipients, sessionIds, amounts, properties, "");
     }
 
     function burn(
@@ -2189,34 +2431,33 @@ contract FabricaToken is Context, ERC165, IERC1155, IERC1155MetadataURI, Ownable
      * - `definition` cannot be null.
      */
     function _mint(
-        address to,
+        address[] memory recipients,
         uint sessionId,
+        uint256[] memory amounts,
         Property memory property,
         bytes memory data
     ) internal virtual whenNotPaused returns(uint256) {
-        require(to != address(0), "ERC1155: mint to the zero address");
         require(bytes(property.definition).length > 0, "Definition is required");
         require(sessionId > 0, "Valid sessionId is required");
         require(property.supply > 0, "Minimum supply is 1");
-
+        require(recipients.length == amounts.length, 'Number of recipients and amounts must match');
         // If validator is not specified during mint, use default validator address
         if (property.validator == address(0)) {
             // set default validator address
             property.validator = 0x6fA2Ee5C9841163E88c85a40B70a90FCD5FBB68b;
         }
-        uint256 amount = property.supply;
-
         uint256 id = generateId(_msgSender(), sessionId, property.operatingAgreement);
-
         require(_property[id].supply == 0, "Session ID already exist, please use a different one");
-
-        _balances[id][to] += amount;
+        for (uint256 i = 0; i < recipients.length; i++) {
+            address to = recipients[i];
+            require(to != address(0), "ERC1155: mint to the zero address");
+            uint256 amount = amounts[i];
+            _balances[id][to] += amount;
+            _doSafeTransferAcceptanceCheck(_msgSender(), address(0), to, id, amount, data);
+            emit TransferSingle(_msgSender(), address(0), to, id, amount);
+        }
         // Update property data
         _property[id] = property;
-
-        emit TransferSingle(_msgSender(), address(0), to, id, amount);
-
-        _doSafeTransferAcceptanceCheck(_msgSender(), address(0), to, id, amount, data);
         return id;
     }
 
@@ -2232,45 +2473,45 @@ contract FabricaToken is Context, ERC165, IERC1155, IERC1155MetadataURI, Ownable
      * acceptance magic value.
      */
     function _mintBatch(
-        address to,
+        address[] memory recipients,
         uint256[] memory sessionIds,
+        uint256[] memory amounts,
         Property[] memory properties,
         bytes memory data
     ) internal virtual whenNotPaused returns(uint256[] memory) {
-        require(to != address(0), "ERC1155: mint to the zero address");
+        require(recipients.length == amounts.length, 'Number of recipients and amounts must match');
         require(sessionIds.length == properties.length, "sessionIds and properties length mismatch");
-
         // hit stack too deep error when using more variables, so we use sessionsIds.length in multiple
         // places instead of creating new variables
         uint256[] memory ids = new uint256[](sessionIds.length);
-        uint256[] memory amounts = new uint256[](sessionIds.length);
-
         for (uint256 i = 0; i < sessionIds.length; i++) {
             require(bytes(properties[i].definition).length > 0, "Definition is required");
             require(sessionIds[i] > 0, "Valid sessionId is required");
             require(properties[i].supply > 0, "Minimum supply is 1");
-
             uint256 id = generateId(_msgSender(), sessionIds[i], properties[i].operatingAgreement);
+            for (uint256 j = 0; j < recipients.length; j++) {
+                address to = recipients[j];
+                require(to != address(0), "ERC1155: mint to the zero address");
+                uint256 amount = amounts[j];
+                _balances[id][to] += amount;
+                uint256[] memory amountsForRecipient = new uint256[](ids.length);
+                for (uint256 k = 0; k < ids.length; k++) {
+                    amountsForRecipient[k] = amount;
+                }
+                _doSafeBatchTransferAcceptanceCheck(_msgSender(), address(0), to, ids, amountsForRecipient, data);
+                emit TransferBatch(_msgSender(), address(0), to, ids, amountsForRecipient);
+            }
             require(_property[id].supply == 0, "Session ID already exist, please use a different one");
-
             // If validator is not specified during mint, use default validator address
             if (properties[i].validator == address(0)) {
                 // set default validator address
                 properties[i].validator = 0x6fA2Ee5C9841163E88c85a40B70a90FCD5FBB68b;
             }
-            uint256 amount = properties[i].supply;
-
             ids[i] = id;
-            amounts[i] = amount;
-
-            _balances[id][to] += amount;
             // Update property data
             _property[id] = properties[i];
         }
 
-        emit TransferBatch(_msgSender(), address(0), to, ids, amounts);
-
-        _doSafeBatchTransferAcceptanceCheck(_msgSender(), address(0), to, ids, amounts, data);
         return ids;
     }
 

--- a/src/FabricaToken1155.sol
+++ b/src/FabricaToken1155.sol
@@ -10,6 +10,9 @@ import "@openzeppelin/contracts/utils/Strings.sol";
 import "@openzeppelin/contracts/utils/introspection/ERC165.sol";
 import "@openzeppelin/contracts/utils/introspection/ERC165Checker.sol";
 import "./IFabricaValidator.sol";
+import "@openzeppelin/contracts/utils/math/SafeMath.sol";
+
+using SafeMath for uint256;
 
 /**
  * @dev Implementation of the Fabrica ERC1155 multi-token.
@@ -73,21 +76,27 @@ contract FabricaToken is Context, ERC165, IERC1155, IERC1155MetadataURI, Ownable
      * @dev `mint` allows users to mint to 3rd party (although it allows to mint to self as well)
      */
     function mint(
-        address to,
+        address[] memory recipients,
         uint256 sessionId,
-        uint256 supply,
+        uint256[] memory amounts,
         string memory definition,
         string memory operatingAgreement,
         string memory configuration,
         address validator
     ) public whenNotPaused returns (uint256) {
+        uint256 supply = 0;
+        for (uint256 i = 0; i < amounts.length; i++) {
+            uint256 amount = amounts[i];
+            require(amount > 0, 'Each amount must be greater than zero');
+            supply = supply.add(amount);
+        }
         Property memory property;
         property.supply = supply;
         property.operatingAgreement = operatingAgreement;
         property.definition = definition;
         property.configuration = configuration;
         property.validator = validator;
-        uint256 id = _mint(to, sessionId, property, "");
+        uint256 id = _mint(recipients, sessionId, amounts, property, "");
         return id;
     }
 
@@ -95,24 +104,30 @@ contract FabricaToken is Context, ERC165, IERC1155, IERC1155MetadataURI, Ownable
      * @dev `mintBatch` allows users to mint in bulk
      */
     function mintBatch(
-        address to,
+        address[] memory recipients,
         uint256[] memory sessionIds,
-        uint256[] memory supplies,
+        uint256[] memory amounts,
         string[] memory definitions,
         string[] memory operatingAgreements,
         string[] memory configurations,
         address[] memory validators
     ) public whenNotPaused returns (uint256[] memory ids) {
+        uint256 supply = 0;
+        for (uint256 i = 0; i < amounts.length; i++) {
+            uint256 amount = amounts[i];
+            require(amount > 0, 'Each amount must be greater than zero');
+            supply = supply.add(amount);
+        }
         uint256 size = sessionIds.length;
         Property[] memory properties = new Property[](size);
         for (uint256 i = 0; i < size; i++) {
-            properties[i].supply = supplies[i];
+            properties[i].supply = supply;
             properties[i].operatingAgreement = operatingAgreements[i];
             properties[i].definition = definitions[i];
             properties[i].configuration = configurations[i];
             properties[i].validator = validators[i];
         }
-        ids = _mintBatch(to, sessionIds, properties, "");
+        ids = _mintBatch(recipients, sessionIds, amounts, properties, "");
     }
 
     function burn(
@@ -364,34 +379,33 @@ contract FabricaToken is Context, ERC165, IERC1155, IERC1155MetadataURI, Ownable
      * - `definition` cannot be null.
      */
     function _mint(
-        address to,
+        address[] memory recipients,
         uint sessionId,
+        uint256[] memory amounts,
         Property memory property,
         bytes memory data
     ) internal virtual whenNotPaused returns(uint256) {
-        require(to != address(0), "ERC1155: mint to the zero address");
         require(bytes(property.definition).length > 0, "Definition is required");
         require(sessionId > 0, "Valid sessionId is required");
         require(property.supply > 0, "Minimum supply is 1");
-
+        require(recipients.length == amounts.length, 'Number of recipients and amounts must match');
         // If validator is not specified during mint, use default validator address
         if (property.validator == address(0)) {
             // set default validator address
             property.validator = 0x6fA2Ee5C9841163E88c85a40B70a90FCD5FBB68b;
         }
-        uint256 amount = property.supply;
-
         uint256 id = generateId(_msgSender(), sessionId, property.operatingAgreement);
-
         require(_property[id].supply == 0, "Session ID already exist, please use a different one");
-
-        _balances[id][to] += amount;
+        for (uint256 i = 0; i < recipients.length; i++) {
+            address to = recipients[i];
+            require(to != address(0), "ERC1155: mint to the zero address");
+            uint256 amount = amounts[i];
+            _balances[id][to] += amount;
+            _doSafeTransferAcceptanceCheck(_msgSender(), address(0), to, id, amount, data);
+            emit TransferSingle(_msgSender(), address(0), to, id, amount);
+        }
         // Update property data
         _property[id] = property;
-
-        emit TransferSingle(_msgSender(), address(0), to, id, amount);
-
-        _doSafeTransferAcceptanceCheck(_msgSender(), address(0), to, id, amount, data);
         return id;
     }
 
@@ -407,45 +421,45 @@ contract FabricaToken is Context, ERC165, IERC1155, IERC1155MetadataURI, Ownable
      * acceptance magic value.
      */
     function _mintBatch(
-        address to,
+        address[] memory recipients,
         uint256[] memory sessionIds,
+        uint256[] memory amounts,
         Property[] memory properties,
         bytes memory data
     ) internal virtual whenNotPaused returns(uint256[] memory) {
-        require(to != address(0), "ERC1155: mint to the zero address");
+        require(recipients.length == amounts.length, 'Number of recipients and amounts must match');
         require(sessionIds.length == properties.length, "sessionIds and properties length mismatch");
-
         // hit stack too deep error when using more variables, so we use sessionsIds.length in multiple
         // places instead of creating new variables
         uint256[] memory ids = new uint256[](sessionIds.length);
-        uint256[] memory amounts = new uint256[](sessionIds.length);
-
         for (uint256 i = 0; i < sessionIds.length; i++) {
             require(bytes(properties[i].definition).length > 0, "Definition is required");
             require(sessionIds[i] > 0, "Valid sessionId is required");
             require(properties[i].supply > 0, "Minimum supply is 1");
-
             uint256 id = generateId(_msgSender(), sessionIds[i], properties[i].operatingAgreement);
+            for (uint256 j = 0; j < recipients.length; j++) {
+                address to = recipients[j];
+                require(to != address(0), "ERC1155: mint to the zero address");
+                uint256 amount = amounts[j];
+                _balances[id][to] += amount;
+                uint256[] memory amountsForRecipient = new uint256[](ids.length);
+                for (uint256 k = 0; k < ids.length; k++) {
+                    amountsForRecipient[k] = amount;
+                }
+                _doSafeBatchTransferAcceptanceCheck(_msgSender(), address(0), to, ids, amountsForRecipient, data);
+                emit TransferBatch(_msgSender(), address(0), to, ids, amountsForRecipient);
+            }
             require(_property[id].supply == 0, "Session ID already exist, please use a different one");
-
             // If validator is not specified during mint, use default validator address
             if (properties[i].validator == address(0)) {
                 // set default validator address
                 properties[i].validator = 0x6fA2Ee5C9841163E88c85a40B70a90FCD5FBB68b;
             }
-            uint256 amount = properties[i].supply;
-
             ids[i] = id;
-            amounts[i] = amount;
-
-            _balances[id][to] += amount;
             // Update property data
             _property[id] = properties[i];
         }
 
-        emit TransferBatch(_msgSender(), address(0), to, ids, amounts);
-
-        _doSafeBatchTransferAcceptanceCheck(_msgSender(), address(0), to, ids, amounts, data);
         return ids;
     }
 

--- a/src/FabricaToken1155Testnet.sol
+++ b/src/FabricaToken1155Testnet.sol
@@ -10,6 +10,9 @@ import "@openzeppelin/contracts/utils/Strings.sol";
 import "@openzeppelin/contracts/utils/introspection/ERC165.sol";
 import "@openzeppelin/contracts/utils/introspection/ERC165Checker.sol";
 import "./IFabricaValidator.sol";
+import "@openzeppelin/contracts/utils/math/SafeMath.sol";
+
+using SafeMath for uint256;
 
 /**
  * @dev Implementation of the Fabrica ERC1155 multi-token.
@@ -73,21 +76,27 @@ contract FabricaToken is Context, ERC165, IERC1155, IERC1155MetadataURI, Ownable
      * @dev `mint` allows users to mint to 3rd party (although it allows to mint to self as well)
      */
     function mint(
-        address to,
+        address[] memory recipients,
         uint256 sessionId,
-        uint256 supply,
+        uint256[] memory amounts,
         string memory definition,
         string memory operatingAgreement,
         string memory configuration,
         address validator
     ) public whenNotPaused returns (uint256) {
+        uint256 supply = 0;
+        for (uint256 i = 0; i < amounts.length; i++) {
+            uint256 amount = amounts[i];
+            require(amount > 0, 'Each amount must be greater than zero');
+            supply = supply.add(amount);
+        }
         Property memory property;
         property.supply = supply;
         property.operatingAgreement = operatingAgreement;
         property.definition = definition;
         property.configuration = configuration;
         property.validator = validator;
-        uint256 id = _mint(to, sessionId, property, "");
+        uint256 id = _mint(recipients, sessionId, amounts, property, "");
         return id;
     }
 
@@ -95,24 +104,30 @@ contract FabricaToken is Context, ERC165, IERC1155, IERC1155MetadataURI, Ownable
      * @dev `mintBatch` allows users to mint in bulk
      */
     function mintBatch(
-        address to,
+        address[] memory recipients,
         uint256[] memory sessionIds,
-        uint256[] memory supplies,
+        uint256[] memory amounts,
         string[] memory definitions,
         string[] memory operatingAgreements,
         string[] memory configurations,
         address[] memory validators
     ) public whenNotPaused returns (uint256[] memory ids) {
+        uint256 supply = 0;
+        for (uint256 i = 0; i < amounts.length; i++) {
+            uint256 amount = amounts[i];
+            require(amount > 0, 'Each amount must be greater than zero');
+            supply = supply.add(amount);
+        }
         uint256 size = sessionIds.length;
         Property[] memory properties = new Property[](size);
         for (uint256 i = 0; i < size; i++) {
-            properties[i].supply = supplies[i];
+            properties[i].supply = supply;
             properties[i].operatingAgreement = operatingAgreements[i];
             properties[i].definition = definitions[i];
             properties[i].configuration = configurations[i];
             properties[i].validator = validators[i];
         }
-        ids = _mintBatch(to, sessionIds, properties, "");
+        ids = _mintBatch(recipients, sessionIds, amounts, properties, "");
     }
 
     function burn(
@@ -364,34 +379,33 @@ contract FabricaToken is Context, ERC165, IERC1155, IERC1155MetadataURI, Ownable
      * - `definition` cannot be null.
      */
     function _mint(
-        address to,
+        address[] memory recipients,
         uint sessionId,
+        uint256[] memory amounts,
         Property memory property,
         bytes memory data
     ) internal virtual whenNotPaused returns(uint256) {
-        require(to != address(0), "ERC1155: mint to the zero address");
         require(bytes(property.definition).length > 0, "Definition is required");
         require(sessionId > 0, "Valid sessionId is required");
         require(property.supply > 0, "Minimum supply is 1");
-
+        require(recipients.length == amounts.length, 'Number of recipients and amounts must match');
         // If validator is not specified during mint, use default validator address
         if (property.validator == address(0)) {
             // set default validator address
             property.validator = 0xFF9dAe0F64382e9dDc0918A7704eF4777A7e0D6F;
         }
-        uint256 amount = property.supply;
-
         uint256 id = generateId(_msgSender(), sessionId, property.operatingAgreement);
-
         require(_property[id].supply == 0, "Session ID already exist, please use a different one");
-
-        _balances[id][to] += amount;
+        for (uint256 i = 0; i < recipients.length; i++) {
+            address to = recipients[i];
+            require(to != address(0), "ERC1155: mint to the zero address");
+            uint256 amount = amounts[i];
+            _balances[id][to] += amount;
+            _doSafeTransferAcceptanceCheck(_msgSender(), address(0), to, id, amount, data);
+            emit TransferSingle(_msgSender(), address(0), to, id, amount);
+        }
         // Update property data
         _property[id] = property;
-
-        emit TransferSingle(_msgSender(), address(0), to, id, amount);
-
-        _doSafeTransferAcceptanceCheck(_msgSender(), address(0), to, id, amount, data);
         return id;
     }
 
@@ -407,45 +421,45 @@ contract FabricaToken is Context, ERC165, IERC1155, IERC1155MetadataURI, Ownable
      * acceptance magic value.
      */
     function _mintBatch(
-        address to,
+        address[] memory recipients,
         uint256[] memory sessionIds,
+        uint256[] memory amounts,
         Property[] memory properties,
         bytes memory data
     ) internal virtual whenNotPaused returns(uint256[] memory) {
-        require(to != address(0), "ERC1155: mint to the zero address");
+        require(recipients.length == amounts.length, 'Number of recipients and amounts must match');
         require(sessionIds.length == properties.length, "sessionIds and properties length mismatch");
-
         // hit stack too deep error when using more variables, so we use sessionsIds.length in multiple
         // places instead of creating new variables
         uint256[] memory ids = new uint256[](sessionIds.length);
-        uint256[] memory amounts = new uint256[](sessionIds.length);
-
         for (uint256 i = 0; i < sessionIds.length; i++) {
             require(bytes(properties[i].definition).length > 0, "Definition is required");
             require(sessionIds[i] > 0, "Valid sessionId is required");
             require(properties[i].supply > 0, "Minimum supply is 1");
-
             uint256 id = generateId(_msgSender(), sessionIds[i], properties[i].operatingAgreement);
+            for (uint256 j = 0; j < recipients.length; j++) {
+                address to = recipients[j];
+                require(to != address(0), "ERC1155: mint to the zero address");
+                uint256 amount = amounts[j];
+                _balances[id][to] += amount;
+                uint256[] memory amountsForRecipient = new uint256[](ids.length);
+                for (uint256 k = 0; k < ids.length; k++) {
+                    amountsForRecipient[k] = amount;
+                }
+                _doSafeBatchTransferAcceptanceCheck(_msgSender(), address(0), to, ids, amountsForRecipient, data);
+                emit TransferBatch(_msgSender(), address(0), to, ids, amountsForRecipient);
+            }
             require(_property[id].supply == 0, "Session ID already exist, please use a different one");
-
             // If validator is not specified during mint, use default validator address
             if (properties[i].validator == address(0)) {
                 // set default validator address
                 properties[i].validator = 0xFF9dAe0F64382e9dDc0918A7704eF4777A7e0D6F;
             }
-            uint256 amount = properties[i].supply;
-
             ids[i] = id;
-            amounts[i] = amount;
-
-            _balances[id][to] += amount;
             // Update property data
             _property[id] = properties[i];
         }
 
-        emit TransferBatch(_msgSender(), address(0), to, ids, amounts);
-
-        _doSafeBatchTransferAcceptanceCheck(_msgSender(), address(0), to, ids, amounts, data);
         return ids;
     }
 

--- a/test/FabricaToken1155.test.ts
+++ b/test/FabricaToken1155.test.ts
@@ -24,28 +24,28 @@ describe('FabricaToken', async () => {
     const definition = "definition";
     const operatingAgreement = "operatingAgreement";
     const configuration = "configuration";
-    const result = await token.mint(walletTo.address, sessionId, supply, definition, operatingAgreement, configuration, validator.address);
+    const result = await token.mint([walletTo.address], sessionId, [supply], definition, operatingAgreement, configuration, validator.address);
     const { data: tokenId } = result;
 
-    // const generatedId = await token.generateId(walletTo.address, sessionId, operatingAgreement);
-    // const decoded = BigNumber.from(generatedId._hex).toString();
-    // console.log('zzz tokenId', tokenId);
-    // console.log('zzz generatedId', generatedId);
-    // console.log('zzz decoded', decoded);
+    const generatedId = await token.generateId(walletTo.address, sessionId, operatingAgreement);
+    const decoded = BigNumber.from(generatedId._hex).toString();
+    console.log('zzz tokenId', tokenId);
+    console.log('zzz generatedId', generatedId);
+    console.log('zzz decoded', decoded);
 
-    // const balanceOf = await token.balanceOf(walletTo.address, generatedId._hex);
-    // console.log('zzz balanceOf', balanceOf);
+    const balanceOf = await token.balanceOf(walletTo.address, generatedId._hex);
+    console.log('zzz balanceOf', balanceOf);
 
     assert(tokenId);
   });
 
   it('Batch mint succeeds and returns an array of tokenIds', async () => {
     const sessionIds = [2, 3];
-    const supplies = [10, 20];
+    const supply = 20;
     const definitions = ["definition 1", "definition 2"];
     const operatingAgreements = ["operatingAgreement 1", "ops 2"];
     const configurations = ["configuration 1", "config 2"];
-    const { data: tokenIds } = await token.mintBatch(walletTo.address, sessionIds, supplies, definitions, operatingAgreements, configurations, [validator.address, validator.address]);
+    const { data: tokenIds } = await token.mintBatch([walletTo.address], sessionIds, [supply], definitions, operatingAgreements, configurations, [validator.address, validator.address]);
 
     assert(tokenIds);
   });

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,6 @@
+{
+  "compilerOptions": {
+    "esModuleInterop": true,
+    "resolveJsonModule": true
+  }
+}


### PR DESCRIPTION
See the attached Linear issue for requirements. Note that this changes the meaning of "amounts" on a batch mint: it is no longer an array of supplies, separate for each token; rather, it is an array of supply for each recipient. Each recipient will receive the same amount of supply for every token minted.